### PR TITLE
Corrected memory leaks calling abi::__cxa_demangle

### DIFF
--- a/ce_angelscript_ex/as_typeid.cpp
+++ b/ce_angelscript_ex/as_typeid.cpp
@@ -49,6 +49,8 @@ std::string as_class_name(const std::type_info& type)
    int s=0;
    char* p = abi::__cxa_demangle(name.c_str(),0,&len,&s);
    name = p;
+   // _cxa_demangle documentation says user is responsible for deallocating the memory
+   std::free(p);
 #endif
    return name;
 }

--- a/op_lite/op_class_name.cpp
+++ b/op_lite/op_class_name.cpp
@@ -20,6 +20,8 @@ std::string op_class_name(const std::string& typeid_name)
    int s=0;
    char* p = abi::__cxa_demangle(typeid_name.c_str(),0,&len,&s);
    name = p;
+   // _cxa_demangle documentation says user is responsible for deallocating the memory
+   std::free(p);
 #endif
    return name;
 }


### PR DESCRIPTION
User of __cxa_demangle must call std::free after the call to deallocate the buffer. See https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html